### PR TITLE
Fixing an issue with empty error lines in the logs

### DIFF
--- a/Src/NuGetDefense.Core/NuGetFile.cs
+++ b/Src/NuGetDefense.Core/NuGetFile.cs
@@ -169,7 +169,7 @@ namespace NuGetDefense.Core
                 return new Dictionary<string, NuGetPackage>();
             }
 
-            if (errorOutputBuilder.Length > 1) Console.WriteLine($"`dotnet list` Errors: {errorOutputBuilder}");
+            if (errorOutputBuilder.ToString().Trim().Length > 1) Console.WriteLine($"`dotnet list` Errors: {errorOutputBuilder}");
 
             pkgs = ParseListPackages(outputBuilder.ToString());
 


### PR DESCRIPTION
In reference of a reported issue in [NuGetDefense](https://github.com/digitalcoyote/NuGetDefense/issues/62) I tracked down the reason of the empty error messages. I suspect something changed with the output of the `dotnet list` command. This change will prevent that log from appearing, since it isn't needed.