### PR TITLE
Fixes #216

### DIFF
--- a/Src/CoreTests/MSBuildLoggerTests.cs
+++ b/Src/CoreTests/MSBuildLoggerTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using NuGetDefense;
+using NuGetDefense.Core;
+using Xunit;
+
+namespace CoreTests
+{
+    public class MsBuildLoggerTests
+    {
+        private const string Code = "ND0001";
+        private const string Message = "Dependency issue detected.";
+        private const int LineNumber = 17;
+        private const int LinePosition = 3;
+
+        [Fact]
+        public void Log_WithNullFile_UsesFallbackFileName()
+        {
+            // Arrange
+            string? file = null;
+            var category = MsBuild.Category.Warning;
+
+            // Act
+            var result = MsBuild.Log(file, category, Code, LineNumber, LinePosition, Message);
+
+            // Assert
+            result.Should().Be($"NuGetDefense({LineNumber},{LinePosition}) : Warning : {Code} : {Message}");
+        }
+
+        [Fact]
+        public void Log_WithFile_UsesProvidedFileName()
+        {
+            // Arrange
+            string file = "packages.lock.json";
+            var category = MsBuild.Category.Error;
+
+            // Act
+            var result = MsBuild.Log(file, category, Code, LineNumber, LinePosition, Message);
+
+            // Assert
+            result.Should().Be($"packages.lock.json({LineNumber},{LinePosition}) : Error : {Code} : {Message}");
+        }
+    }
+}

--- a/Src/NuGetDefense.Core/MSBuildLogger.cs
+++ b/Src/NuGetDefense.Core/MSBuildLogger.cs
@@ -6,6 +6,10 @@ namespace NuGetDefense.Core
     /// </summary>
     public static class MsBuild
     {
+        /// <summary>
+        /// Fallback file name to use if provided file is null.
+        /// </summary>
+        private const string FallbackFileName = "NuGetDefense";
         public enum Category
         {
             Warning,
@@ -21,8 +25,9 @@ namespace NuGetDefense.Core
         /// <param name="linePosition">1 based index to use to reference where in the file the problem is</param>
         /// <param name="category">Warning or Error</param>
         /// <param name="text">message for the error</param>
-        public static string Log(string file, Category category, string code, int? lineNumber, int? linePosition, string text)
+        public static string Log(string? file, Category category, string code, int? lineNumber, int? linePosition, string text)
         {
+            file ??= FallbackFileName;
             return
                 $"{file}({lineNumber},{linePosition}) : {category.ToString()} : {code} : {text}";
         }
@@ -36,6 +41,7 @@ namespace NuGetDefense.Core
         /// <param name="text">message for the error</param>
         public static string Log(string file, Category category, string code, string text)
         {
+            file ??= FallbackFileName;
             return
                 $"{file}: {category.ToString()} : {code} : {text}";
         }
@@ -48,6 +54,7 @@ namespace NuGetDefense.Core
         /// <param name="text">message for the error</param>
         public static string Log(string file, Category category, string text)
         {
+            file ??= FallbackFileName;
             return
                 $"{file}: {category.ToString()} : {text}";
         }
@@ -62,6 +69,7 @@ namespace NuGetDefense.Core
         /// <param name="text">message for the error</param>
         public static string Log(string file, Category category, int? lineNumber, int? linePosition, string text)
         {
+            file ??= FallbackFileName;
             return
                 $"{file}({lineNumber},{linePosition}) : {category.ToString()} : {text}";
         }

--- a/Src/NuGetDefense.Core/MSBuildLogger.cs
+++ b/Src/NuGetDefense.Core/MSBuildLogger.cs
@@ -39,7 +39,7 @@ namespace NuGetDefense.Core
         /// <param name="code">Code to use to identify the problem</param>
         /// <param name="category">Warning or Error</param>
         /// <param name="text">message for the error</param>
-        public static string Log(string file, Category category, string code, string text)
+        public static string Log(string? file, Category category, string code, string text)
         {
             file ??= FallbackFileName;
             return
@@ -52,7 +52,7 @@ namespace NuGetDefense.Core
         /// <param name="file">file the problem is in</param>
         /// <param name="category">Warning or Error</param>
         /// <param name="text">message for the error</param>
-        public static string Log(string file, Category category, string text)
+        public static string Log(string? file, Category category, string text)
         {
             file ??= FallbackFileName;
             return
@@ -67,7 +67,7 @@ namespace NuGetDefense.Core
         /// <param name="linePosition">1 based index to use to reference where in the file the problem is</param>
         /// <param name="category">Warning or Error</param>
         /// <param name="text">message for the error</param>
-        public static string Log(string file, Category category, int? lineNumber, int? linePosition, string text)
+        public static string Log(string? file, Category category, int? lineNumber, int? linePosition, string text)
         {
             file ??= FallbackFileName;
             return


### PR DESCRIPTION
This fixes https://github.com/digitalcoyote/NuGetDefense/issues/216 by adding a default fallback string to use in case file is null.
